### PR TITLE
bugfix: fix boot time failure w/o hw acceleration

### DIFF
--- a/PVE/QemuServer.pm
+++ b/PVE/QemuServer.pm
@@ -2850,7 +2850,8 @@ sub config_to_command {
 
     $cpu .= "," . join(',', @$cpuFlags) if scalar(@$cpuFlags);
 
-    push @$cmd, '-cpu', "$cpu,enforce";
+    $cpu .= ",enforce" if !$nokvm;
+    push @$cmd, '-cpu', $cpu;
 
     my $memory = $conf->{memory} || $defaults->{memory};
     my $static_memory = 0;


### PR DESCRIPTION
Since a commit 6a33d44, the enforce options is enabled by default but
in kvm without hw acceleration, this option is not available.