### PR TITLE
Update QemuServer.pm

### DIFF
--- a/PVE/QemuServer.pm
+++ b/PVE/QemuServer.pm
@@ -3344,12 +3344,6 @@ sub config_to_command {
 	}
     }
 
-    # add custom args
-    if ($conf->{args}) {
-	my $aa = PVE::Tools::split_args($conf->{args});
-	push @$cmd, @$aa;
-    }
-
     push @$cmd, @$devices;
     push @$cmd, '-rtc', join(',', @$rtcFlags)
 	if scalar(@$rtcFlags);
@@ -3357,7 +3351,12 @@ sub config_to_command {
 	if scalar(@$machineFlags);
     push @$cmd, '-global', join(',', @$globalFlags)
 	if scalar(@$globalFlags);
-
+	
+    # add custom args
+    if ($conf->{args}) {
+	my $aa = PVE::Tools::split_args($conf->{args});
+	push @$cmd, @$aa;
+    }
     return wantarray ? ($cmd, $vollist, $spice_port) : $cmd;
 }
 


### PR DESCRIPTION
Because of not all of custom args works properly. Like a  -virtfs local,path=/mnt,security_model=none,mount_tag=share or something else, which i found in the google. 
Error while starting VM is kvm: -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x3: PCI: slot 3 function 0 not available for virtio-balloon-pci, in use by virtio-9p-pci

I think custom args must be in the end of all other args. Now it works properly for me.
Please change it, if it correct. Thanks